### PR TITLE
.rspec ファイルを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.rbc
 capybara-*.html
-.rspec
 /log
 /tmp
 /db/*.sqlite3

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require rails_helper


### PR DESCRIPTION
.rspec ファイルのデフォルトは `spec_helper` の読み込みになっているが、rails_helper を読み込むように修正。（rails_helper 内で spec_helper を require している）