### PR TITLE
enterprises の create メソッドを調整

### DIFF
--- a/app/models/enterprise.rb
+++ b/app/models/enterprise.rb
@@ -1,2 +1,5 @@
 class Enterprise < ApplicationRecord
+  has_many :accounts, dependent: :destroy
+  has_many :users, through: :accounts
+  has_many :channels
 end

--- a/spec/requests/enterprises_spec.rb
+++ b/spec/requests/enterprises_spec.rb
@@ -16,4 +16,26 @@ describe "Enterprises API", type: :request do
       end
     end
   end
+
+  describe "POST /enterprises" do
+    context "新しいチームを作成" do
+      context "自身が所属する新規チームを作成するとき" do
+        subject { post "/enterprises", @params }
+
+        before {
+          @attributes = attributes_for(:enterprise)
+          @params = { enterprise: @attributes }
+        }
+
+        fit "成功する" do
+          expect(subject).to eq 200
+          parsed_body = response.parsed_body
+          aggregate_failures do
+            expect(parsed_body["name"]).to eq @attributes[:name]
+            expect(parsed_body["account_name"]).to eq @attributes[:account_name]
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
 - enterprise#create で、作成者のアカウントを同時に作成, 新規チームの account_id を session に保存