### PR TITLE
新規チーム作成時に general チャンネルも作成するように API を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ capybara-*.html
 *.orig
 rerun.txt
 pickle-email-*.html
+dump.rdb
 
 config/initializers/secret_token.rb
 config/secrets.yml

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -1,5 +1,5 @@
 class EnterprisesController < ApplicationController
-  before_action :set_enterprise, only: [:show, :edit, :update, :destroy]
+  before_action :set_enterprise, only: [:show, :destroy]
 
   def index
     @enterprises = current_user.enterprises
@@ -12,9 +12,9 @@ class EnterprisesController < ApplicationController
     # TODO: model にロジックを移したい
     ActiveRecord::Base.transaction do
       @enterprise = Enterprise.create!(enterprise_params)
-      account = current_user.accounts.create!(enterprise: @enterprise, role: Account.roles["owner"])
-      # TODO: general チャンネルの作成
-      session[:account_id] = account.id
+      owner_account = current_user.accounts.create!(enterprise: @enterprise, role: Account.roles["owner"])
+      general_channel = owner_account.channels.create!(name: "general", enterprise: @enterprise, owner_id: owner_account.id)
+      session[:account_id] = owner_account.id
     end
     render :show
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,5 +1,8 @@
 class Account < ApplicationRecord
   belongs_to :user
   belongs_to :enterprise
+  has_many   :channel_members
+  has_many   :channels, through: :channel_members
+  has_many   :messages
   enum role: { owner: 0, manager: 1, viewer: 2 }
 end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,2 +1,7 @@
 class Channel < ApplicationRecord
+  belongs_to :account, foreign_key: :owner_id
+  belongs_to :enterprise
+  has_many :channel_members
+  has_many :accounts, through: :channel_members
+  has_many :messages
 end

--- a/app/models/channel_member.rb
+++ b/app/models/channel_member.rb
@@ -1,0 +1,5 @@
+class ChannelMember < ApplicationRecord
+  belongs_to :account
+  belongs_to :channel
+  has_many :messages
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,2 +1,4 @@
 class Message < ApplicationRecord
+  belongs_to :channel
+  belongs_to :account
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resources :messages
   resources :channels
   root to: "main#main"
-  resources :enterprises
+  resources :enterprises, only: [:index, :show, :create, :destroy]
   devise_for :users, only: [:sign_in, :sign_out, :session], controllers: {
     registrations: :'users/registrations',
     # sessions:      :'users/sessions'

--- a/db/migrate/20170709154418_create_channels.rb
+++ b/db/migrate/20170709154418_create_channels.rb
@@ -1,10 +1,9 @@
 class CreateChannels < ActiveRecord::Migration[5.1]
   def change
     create_table :channels do |t|
+      t.string  :name
       t.integer :enterprise_id, null: false
       t.integer :owner_id, null: false
-      t.string  :name
-      t.integer :user_id, null: false
       t.timestamps
     end
   end

--- a/db/migrate/20170714051101_create_channel_members.rb
+++ b/db/migrate/20170714051101_create_channel_members.rb
@@ -1,0 +1,10 @@
+class CreateChannelMembers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :channel_members do |t|
+      t.integer :account_id
+      t.integer :channel_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170710133322) do
+ActiveRecord::Schema.define(version: 20170714051101) do
 
   create_table "accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -21,11 +21,17 @@ ActiveRecord::Schema.define(version: 20170710133322) do
     t.index ["user_id", "enterprise_id"], name: "index_accounts_on_user_and_enterprise", unique: true
   end
 
+  create_table "channel_members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "account_id"
+    t.integer "channel_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "channels", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name"
     t.integer "enterprise_id", null: false
     t.integer "owner_id", null: false
-    t.string "name"
-    t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/requests/enterprises_spec.rb
+++ b/spec/requests/enterprises_spec.rb
@@ -27,7 +27,7 @@ describe "Enterprises API", type: :request do
           @params = { enterprise: @attributes }
         }
 
-        fit "成功する" do
+        it "成功する" do
           expect(subject).to eq 200
           parsed_body = response.parsed_body
           aggregate_failures do


### PR DESCRIPTION
## 概要
 - enterprises まわりの未修正部分を追加
 - accounts と channels の中間テーブルを追加
 - model に has_many, belongs_to などの定義を追加