### PR TITLE
CSRF 対策をOFF, domain 指定を localhost に変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception, unless: :need_oauth_authenticate
+  # protect_from_forgery with: :exception, unless: :need_oauth_authenticate
 
   before_action :authenticate_user!
   before_action :doorkeeper_authorize!, if: :need_oauth_authenticate

--- a/app/javascript/packs/actions/chat.jsx
+++ b/app/javascript/packs/actions/chat.jsx
@@ -43,7 +43,7 @@ function receiveChannels(json) {
 export function fetchChannels() {
   return dispatch => {
     dispatch(requestChannels())
-    return axios.get('http://127.0.0.1:3000/channels.json').then((response) => {
+    return axios.get('http://localhost:3000/channels.json').then((response) => {
         dispatch(receiveChannels(response.data))
       }).catch((response) => {
         console.log(response)


### PR DESCRIPTION
 - 一時的に `protect_from_forgery` をコメントアウト
 - chat.jsx の ドメイン指定を localhost に変更